### PR TITLE
chore: Replace devops-ci with platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,22 +7,22 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.github/                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/devops-ci-committers
-.remarkrc                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/devops-ci-committers
+/config/                                        @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/platform-ci-committers
+.remarkrc                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/platform-ci-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/devops-ci-committers @hashgraph/developer-advocates
+/README.md                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-ci-committers @hashgraph/developer-advocates
 **/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/codecov.yml                                  @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/devops-ci-committers
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/devops-ci-committers
+**/.gitignore                                   @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-ci-committers
+**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-ci-committers


### PR DESCRIPTION
**Description**:
Replace devops-ci with platform-ci

**Related issue(s)**:

Fixes #34